### PR TITLE
Update Open Graph tags to reflect new dates

### DIFF
--- a/server/templates/html.html
+++ b/server/templates/html.html
@@ -9,12 +9,12 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
         <title>{% block title %}Techbikers{% endblock %}</title>
-        <meta name="description" content="On September 18th, 60+ techies will ride from Paris to London. Over the 3 day, 200 mile ride they will raise $75000+ for Room to Read.">
+        <meta name="description" content="On June 24th, 60+ techies will ride from Paris to London. Over the 3 day, 200 mile ride they will raise $75000+ for Room to Read.">
 
         <meta property="og:image" content="https://techbikers.com{% static 'img/techbikers_144px.png' %}"/>
         <meta property="og:title" content="Techbikers - Paris to London charity cycle ride"/>
         <meta property="og:url" content="https://techbikers.com"/>
-        <meta property="og:description" content="On September 18th, 60+ techies will ride from Paris to London. Over the 3 day, 200 mile ride they will raise $75000+ for Room to Read."/>
+        <meta property="og:description" content="On June 24th, 60+ techies will ride from Paris to London. Over the 3 day, 200 mile ride they will raise $75000+ for Room to Read."/>
 
         <link rel="stylesheet" href="{% static 'css/main.css' %}">
 


### PR DESCRIPTION
@mwillmott is probably working on showing different tags for each of the
rides, but this is a hotfix we can use for the current one.  When
deployed, the Facebook OG cache needs to be cleared by pasting the ride URL
(https://techbikers.com/rides/8/paris-london-2016) into this form:

https://developers.facebook.com/tools/debug/