### PR TITLE
Disable ESLint

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -225,7 +225,7 @@ module.exports = options => {
     entry,
     output,
     module: {
-      preLoaders: [].concat(loadersByExtension(preLoaders)),
+      // preLoaders: [].concat(loadersByExtension(preLoaders)),
       loaders: [].concat(loadersByExtension(loaders)).concat(loadersByExtension(stylesheetLoaders)).concat(additionalLoaders),
       noParse: []
     },


### PR DESCRIPTION
It's breaking the build. We should re-enable it when we fix all errors.